### PR TITLE
Added python version check to install

### DIFF
--- a/abr_jaco2/__init__.py
+++ b/abr_jaco2/__init__.py
@@ -1,3 +1,14 @@
 from .config.config import Config
 from .interface.interface import Interface
 from .interface import jaco2_rs485
+import sys
+
+if sys.version_info > (3, 6, 9):
+    raise ImportError(
+        """
+You are using Python version %s and abr_jaco2
+currently supports python up to 3.6.9.
+
+Please create a new environment with python =<3.6.9
+"""
+% (sys.version))

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
     long_description=read('README.rst'),
     install_requires=setup_requires + install_requires,
     setup_requires=setup_requires,
+    python_requires="<3.7",
     extras_require={"tests": tests_require},
     cmdclass = {'build_ext': build_ext},
     ext_modules=[


### PR DESCRIPTION
- added python requires to limit to python<=3.6.9 due to issues
  with cython and python 3.7
- added exception to throw error on import if python>=3.7